### PR TITLE
Add CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,43 @@
+---
+version: 2
+jobs:
+  build:
+    docker:
+      - image: alexdzyoba/nginx-vts-builder:debian-9
+    working_directory: /build
+    steps:
+      - run:
+          name: "Build the nginx-vts package"
+          command: /build/build.sh
+      - persist_to_workspace:
+          name: "Store output in the CI workspace for upload to Github Releases"
+          root: /
+          paths:
+            - output
+
+  release:
+    docker:
+      - image: cibuilds/github:0.12
+    steps:
+      - attach_workspace:
+          at: ./artifacts
+      - run:
+          name: "Publish Release on GitHub"
+          command: |
+            ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -replace ${CIRCLE_TAG} ./artifacts/output/
+
+workflows:
+  version: 2
+  release:
+    jobs:
+      - build
+          filters:
+            tags:
+              only: /.*/
+      - release:
+          requires:
+            - build
+          filters:
+            tags:
+              only: /.*/
+


### PR DESCRIPTION
We need to automate the release process and also utilize Github Releases
as a simple distribution medium so people can download packages directly
from Github.

We use CircleCI because it works great with containers. The build stage
uses nginx-vts-builder public image and invokes build.sh script.

The release stage uses artifacts from build stage via workspace feature
and then uploads the packages to the Github Releases using ghr tool.

build and release jobs are run only on tags because the idea is to
create tag with nginx and vts versions like 1.15.7-0.1.18 and have a
package with these versions on Github Releases.